### PR TITLE
store and block improvements, added first and several benchmarks, introducing internalState

### DIFF
--- a/core/block.go
+++ b/core/block.go
@@ -32,6 +32,7 @@ func NewBlock(s Spec) *Block {
 		state: BlockState{
 			make(MessageMap),
 			make(MessageMap),
+			make(MessageMap),
 			make(Manifest),
 			false,
 		},
@@ -208,6 +209,7 @@ func (b *Block) process() Interrupt {
 	// run the kernel
 	interrupt := b.kernel(b.state.inputValues,
 		b.state.outputValues,
+		b.state.internalValues,
 		b.routing.Shared.Store,
 		b.routing.InterruptChan)
 

--- a/core/block_test.go
+++ b/core/block_test.go
@@ -91,7 +91,26 @@ func TestKeyValue(t *testing.T) {
 
 }
 
+func TestFirst(t *testing.T) {
+	log.Println("testing first")
+	f := NewBlock(GetLibrary()["first"])
+	go f.Serve()
+	sink := make(chan Message)
+	f.Connect(0, sink)
+
+	expected := []interface{}{true, false, false, false, false}
+	in := f.Input(0).C
+
+	for i, v := range expected {
+		in <- i
+		if v != <-sink {
+			t.Error("first did not produce expected results")
+		}
+	}
+}
+
 func TestNull(t *testing.T) {
+	log.Println("testing null stream")
 	null := NewBlock(GetLibrary()["identity"])
 	go null.Serve()
 	null.RouteValue(0, nil)

--- a/core/blocks_test.go
+++ b/core/blocks_test.go
@@ -63,7 +63,7 @@ func TestSimpleDyads(t *testing.T) {
 		log.Println("testing", blockType)
 		ic := make(chan Interrupt)
 		out := MessageMap{}
-		interrupt := block.Kernel(test.in, out, nil, ic)
+		interrupt := block.Kernel(test.in, out, nil, nil, ic)
 		for k, v := range test.expected {
 			r, ok := out[k]
 			if !ok {
@@ -94,7 +94,7 @@ func TestDelay(t *testing.T) {
 	timer := time.AfterFunc(timerDuration+tolerance, func() {
 		t.Error("delay took longer than specified duration +", tolerance)
 	})
-	interrupt := spec.Kernel(in, out, nil, ic)
+	interrupt := spec.Kernel(in, out, nil, nil, ic)
 	timer.Stop()
 	if out[0] != expected[0] {
 		t.Error("delay didn't pass the correct message")

--- a/core/keyvalue.go
+++ b/core/keyvalue.go
@@ -23,7 +23,7 @@ func kvGet() Spec {
 			Pin{"value"},
 		},
 		Shared: KEY_VALUE,
-		Kernel: func(in MessageMap, out MessageMap, s Store, i chan Interrupt) Interrupt {
+		Kernel: func(in, out, internal MessageMap, s Store, i chan Interrupt) Interrupt {
 			kv := s.(*KeyValue)
 			key, ok := in[0].(string)
 			if !ok {
@@ -53,7 +53,7 @@ func kvSet() Spec {
 			Pin{"new"},
 		},
 		Shared: KEY_VALUE,
-		Kernel: func(in MessageMap, out MessageMap, s Store, i chan Interrupt) Interrupt {
+		Kernel: func(in, out, internal MessageMap, s Store, i chan Interrupt) Interrupt {
 			kv := s.(*KeyValue)
 			key, ok := in[0].(string)
 			if !ok {
@@ -85,7 +85,7 @@ func kvClear() Spec {
 			Pin{"cleared"},
 		},
 		Shared: KEY_VALUE,
-		Kernel: func(in MessageMap, out MessageMap, s Store, i chan Interrupt) Interrupt {
+		Kernel: func(in, out, internal MessageMap, s Store, i chan Interrupt) Interrupt {
 			kv := s.(*KeyValue)
 			kv.kv = make(map[string]Message)
 			out[0] = true
@@ -107,7 +107,7 @@ func kvDump() Spec {
 			Pin{"object"},
 		},
 		Shared: KEY_VALUE,
-		Kernel: func(in MessageMap, out MessageMap, s Store, i chan Interrupt) Interrupt {
+		Kernel: func(in, out, internal MessageMap, s Store, i chan Interrupt) Interrupt {
 			kv := s.(*KeyValue)
 			outMap := make(map[string]Message)
 			for k, v := range kv.kv {
@@ -129,7 +129,7 @@ func kvDelete() Spec {
 			Pin{"deleted"},
 		},
 		Shared: KEY_VALUE,
-		Kernel: func(in MessageMap, out MessageMap, s Store, i chan Interrupt) Interrupt {
+		Kernel: func(in, out, internal MessageMap, s Store, i chan Interrupt) Interrupt {
 			kv := s.(*KeyValue)
 			key, ok := in[0].(string)
 			if !ok {

--- a/core/random.go
+++ b/core/random.go
@@ -10,7 +10,7 @@ func UniformRandom() Spec {
 	return Spec{
 		Inputs:  []Pin{},
 		Outputs: []Pin{Pin{"draw"}},
-		Kernel: func(in, out MessageMap, s Store, i chan Interrupt) Interrupt {
+		Kernel: func(in, out, internal MessageMap, s Store, i chan Interrupt) Interrupt {
 			out[0] = rand.Float64()
 			return nil
 		},
@@ -23,7 +23,7 @@ func NormalRandom() Spec {
 	return Spec{
 		Inputs:  []Pin{Pin{"mean"}, Pin{"variance"}},
 		Outputs: []Pin{Pin{"draw"}},
-		Kernel: func(in, out MessageMap, s Store, i chan Interrupt) Interrupt {
+		Kernel: func(in, out, internal MessageMap, s Store, i chan Interrupt) Interrupt {
 			variance, ok := in[1].(float64)
 			if !ok {
 				out[0] = NewError("variance must be a float")
@@ -49,7 +49,7 @@ func ZipfRandom() Spec {
 	return Spec{
 		Inputs:  []Pin{Pin{"q"}, Pin{"s"}, Pin{"N"}},
 		Outputs: []Pin{Pin{"draw"}},
-		Kernel: func(in, out MessageMap, ss Store, i chan Interrupt) Interrupt {
+		Kernel: func(in, out, internal MessageMap, ss Store, i chan Interrupt) Interrupt {
 
 			q, ok := in[0].(float64)
 			if !ok {
@@ -93,7 +93,7 @@ func PoissonRandom() Spec {
 	return Spec{
 		Inputs:  []Pin{Pin{"rate"}},
 		Outputs: []Pin{Pin{"draw"}},
-		Kernel: func(in, out MessageMap, ss Store, i chan Interrupt) Interrupt {
+		Kernel: func(in, out, internal MessageMap, ss Store, i chan Interrupt) Interrupt {
 			λ, ok := in[0].(float64)
 			if !ok {
 				out[0] = NewError("rate must be a float")
@@ -114,7 +114,7 @@ func BernoulliRandom() Spec {
 	return Spec{
 		Inputs:  []Pin{Pin{"bias"}},
 		Outputs: []Pin{Pin{"draw"}},
-		Kernel: func(in, out MessageMap, ss Store, i chan Interrupt) Interrupt {
+		Kernel: func(in, out, internal MessageMap, ss Store, i chan Interrupt) Interrupt {
 			r := RAND.Float64()
 			p, ok := in[0].(float64)
 			if !ok {

--- a/core/types.go
+++ b/core/types.go
@@ -26,7 +26,7 @@ type Interrupt func() bool
 
 // Kernel is the core function that operates on an inbound message. It works by populating
 // the outbound MessageMap, and can be interrupted on its Interrupt channel.
-type Kernel func(MessageMap, MessageMap, Store, chan Interrupt) Interrupt
+type Kernel func(MessageMap, MessageMap, MessageMap, Store, chan Interrupt) Interrupt
 
 // A Pin is an inbound or outbound route to a block used in the Spec.
 type Pin struct {
@@ -69,10 +69,11 @@ type Manifest map[ManifestPair]struct{}
 
 // A block's BlockState is the pair of input/output MessageMaps, and the Manifest
 type BlockState struct {
-	inputValues  MessageMap
-	outputValues MessageMap
-	manifest     Manifest
-	Processed    bool
+	inputValues    MessageMap
+	outputValues   MessageMap
+	internalValues MessageMap
+	manifest       Manifest
+	Processed      bool
 }
 
 type Store interface {


### PR DESCRIPTION
Big PR! 
- stores were improved by moving the mutexes outside of the kernel. The mutexes are now conditionally locked by the block. see how this works [here](https://github.com/nikhan/st-core/blob/master/core/block.go#L188). The block will also block if it requires a external store and wait for an interrupt.
- store.go is now keyvalue.go
- key value kernels now fail properly when handed bad data
- added block_test.go, which is meant for testing end-to-end block patterns. Check this out:

GOMAXPROCS=1

```
BenchmarkAddition   2000000000           0.16 ns/op
BenchmarkRandomMath 1000000000           0.89 ns/op
```

GOMAXPROCS=4

```
BenchmarkAddition-4 1000000000           0.59 ns/op
BenchmarkRandomMath-4       5000        216294 ns/op
```

:confounded: :question: :exclamation: 
the docs say that when there is a lot of channel traffic, having more than one proc available can result in a bunch of context switching. something to tune I suppose.
- null stream test verifies that we can stream nulls
- **added internalState** which allows for stateful blocks like First (added this too). This is possibly contentious, but I don't know of any other graceful way to solve it. All internalState is is just a another MessageMap like `in` and `out`, with the only difference is that this map is not cleared each crank. 
