### PR TITLE
import/export

### DIFF
--- a/core/server/group.go
+++ b/core/server/group.go
@@ -294,6 +294,26 @@ func (s *Server) ExportGroup(id int) (*Pattern, error) {
 	}
 
 	p.Groups = append(p.Groups, *g)
+	for _, c := range s.connections {
+		in := false
+		out := false
+		for _, bid := range g.Children {
+			b, ok := s.blocks[bid]
+			if !ok {
+				continue
+			}
+			if b.Id == c.Source.Id {
+				in = true
+			}
+			if b.Id == c.Target.Id {
+				out = true
+			}
+		}
+		if in && out {
+			p.Connections = append(p.Connections, *c)
+		}
+	}
+
 	for _, c := range g.Children {
 		b, ok := s.blocks[c]
 		if !ok {

--- a/core/server/group.go
+++ b/core/server/group.go
@@ -3,7 +3,6 @@ package server
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strconv"
@@ -443,11 +442,17 @@ func (s *Server) ImportGroup(id int, p Pattern) error {
 	}
 
 	for _, g := range p.Groups {
-		n := s.groups[newIds[g.Id]]
 		for _, c := range g.Children {
-			err := s.AddChildToGroup(c, n)
+			var n Node
+			if bn, ok := s.blocks[newIds[c]]; ok {
+				n = bn
+			}
+			if bg, ok := s.groups[newIds[c]]; ok {
+				n = bg
+			}
+
+			err := s.AddChildToGroup(newIds[g.Id], n)
 			if err != nil {
-				fmt.Println(g, n)
 				return err
 			}
 		}


### PR DESCRIPTION
added import and export. to see how it works --

__export.json__
```
{"blocks":[{"label":"","type":"+","id":2,"inputs":[{"name":"addend","type":"const","value":1},{"name":"addend","type":"const","value":1}],"outputs":[{"name":"sum"}],"position":{"x":0,"y":0}},{"label":"","type":"delay","id":3,"inputs":[{"name":"passthrough","type":"fetch","value":"."},{"name":"duration","type":"const","value":"1s"}],"outputs":[{"name":"passthrough"}],"position":{"x":0,"y":0}},{"label":"","type":"log","id":4,"inputs":[{"name":"log","type":"fetch","value":"."}],"outputs":[],"position":{"x":0,"y":0}}],"connections":[{"source":{"id":2,"route":0},"target":{"id":3,"route":0},"id":5},{"source":{"id":3,"route":0},"target":{"id":4,"route":0},"id":6}],"groups":[{"id":0,"label":"root","children":[1],"position":{"x":0,"y":0}},{"id":1,"label":"","children":[2,3,4],"position":{"x":0,"y":0}}]}
```
start st-core and `curl localhost:7071/groups/0/import -d@export.json`
the pattern should print `2` every second
then `curl localhost:7071/groups/0/export` to get the running pattern

you'll see that in the export pattern, the `root` group is included. This means that if you export a pattern and import a pattern you will always wrap one more group around the pattern. This may be undesirable -- in which case we can make it so that the top most group is merged with the group that is receiving the import. 

there were some changes to block.go and connection.go to abstract out parts of the handlers into their own separate functions. 