### PR TITLE
[api] working sources and links

### DIFF
--- a/core/block.go
+++ b/core/block.go
@@ -146,11 +146,18 @@ func (b *Block) GetSource() Source {
 }
 
 // sets a store for the block. can be set to nil
-func (b *Block) SetSource(s Source) {
+func (b *Block) SetSource(s Source) error {
+	returnVal := make(chan error, 1)
 	b.routing.InterruptChan <- func() bool {
+		if s.GetType() != b.sourceType {
+			returnVal <- errors.New("invalid source type for this block")
+			return true
+		}
 		b.routing.Source = s
+		returnVal <- nil
 		return true
 	}
+	return <-returnVal
 }
 
 // RouteValue sets the route to always be the specified value

--- a/core/server/group.go
+++ b/core/server/group.go
@@ -639,5 +639,5 @@ func (s *Server) GroupPositionHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.websocketBroadcast(Update{Action: UPDATE, Type: GROUP, Data: update})
-
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/core/server/group.go
+++ b/core/server/group.go
@@ -3,7 +3,6 @@ package server
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strconv"
@@ -492,8 +491,6 @@ func (s *Server) ImportGroup(id int, p Pattern) error {
 	}
 
 	for _, source := range p.Sources {
-		fmt.Println(source.Parameters)
-		fmt.Println("FUCK FUCK")
 		err := s.ModifySource(newIds[source.Id], source.Parameters)
 		if err != nil {
 			return err

--- a/core/server/group.go
+++ b/core/server/group.go
@@ -177,7 +177,8 @@ func (s *Server) CreateGroup(g ProtoGroup) (*Group, error) {
 	for _, c := range newGroup.Children {
 		_, okb := s.blocks[c]
 		_, okg := s.groups[c]
-		if !okb && !okg {
+		_, oks := s.sources[c]
+		if !okb && !okg && !oks {
 			return nil, errors.New("could not create group: invalid children")
 		}
 	}
@@ -196,6 +197,9 @@ func (s *Server) CreateGroup(g ProtoGroup) (*Group, error) {
 		}
 		if cg, ok := s.groups[c]; ok {
 			err = s.AddChildToGroup(newGroup.Id, cg)
+		}
+		if cs, ok := s.sources[c]; ok {
+			err = s.AddChildToGroup(newGroup.Id, cs)
 		}
 		if err != nil {
 			return nil, err
@@ -426,7 +430,10 @@ func (s *Server) ImportGroup(id int, p Pattern) error {
 	for _, c := range p.Connections {
 		c.Source.Id = newIds[c.Source.Id]
 		c.Target.Id = newIds[c.Target.Id]
-		_, err := s.CreateConnection(c)
+		_, err := s.CreateConnection(ProtoConnection{
+			Source: c.Source,
+			Target: c.Target,
+		})
 		if err != nil {
 			return err
 		}

--- a/core/server/group.go
+++ b/core/server/group.go
@@ -3,6 +3,7 @@ package server
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strconv"
@@ -485,6 +486,15 @@ func (s *Server) ImportGroup(id int, p Pattern) error {
 			Source: l.Source,
 			Block:  l.Block,
 		})
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, source := range p.Sources {
+		fmt.Println(source.Parameters)
+		fmt.Println("FUCK FUCK")
+		err := s.ModifySource(newIds[source.Id], source.Parameters)
 		if err != nil {
 			return err
 		}

--- a/core/server/link.go
+++ b/core/server/link.go
@@ -42,7 +42,7 @@ func (s *Server) CreateLink(l ProtoLink) (*LinkLedger, error) {
 		return nil, errors.New("block and source must be in the same group, cannot link")
 	}
 
-	err := b.Block.SetSource(*sl.Source)
+	err := b.Block.SetSource(sl.Source)
 	if err != nil {
 		return nil, err
 	}

--- a/core/server/link.go
+++ b/core/server/link.go
@@ -39,7 +39,7 @@ func (s *Server) CreateLink(l ProtoLink) (*LinkLedger, error) {
 	}
 
 	if b.GetParent() != sl.GetParent() {
-		return nil, errors.new("block and source must be in the same group, cannot link")
+		return nil, errors.New("block and source must be in the same group, cannot link")
 	}
 
 	err := b.Block.SetSource(*sl.Source)

--- a/core/server/link.go
+++ b/core/server/link.go
@@ -1,0 +1,139 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+
+	"github.com/gorilla/mux"
+)
+
+type LinkLedger struct {
+	Source int `json:"source"` // the source id
+	Block  int `json:"block"`  // the block id
+	Id     int `json:"id"`     // link id
+}
+
+type ProtoLink struct {
+	Source int `json:"source"` // the source id
+	Block  int `json:"block"`  // the block id
+}
+
+func (s *Server) CreateLink(l ProtoLink) (*LinkLedger, error) {
+	b, ok := s.blocks[l.Block]
+	if !ok {
+		return nil, errors.New("could not find block")
+	}
+
+	sl, ok := s.sources[l.Source]
+	if !ok {
+		return nil, errors.New("could not find source")
+	}
+
+	link := &LinkLedger{
+		Source: l.Source,
+		Block:  l.Block,
+		Id:     s.GetNextID(),
+	}
+
+	err := b.Block.SetSource(*sl.Source)
+	if err != nil {
+		return nil, err
+	}
+
+	s.links[link.Id] = link
+
+	s.websocketBroadcast(Update{Action: CREATE, Type: LINK, Data: link})
+
+	return link, nil
+}
+
+func (s *Server) DeleteLink(id int) error {
+	link, ok := s.links[id]
+	if !ok {
+		return errors.New("could not find link")
+	}
+
+	s.blocks[link.Block].Block.SetSource(nil)
+	delete(s.links, id)
+
+	s.websocketBroadcast(Update{Action: CREATE, Type: CONNECTION, Data: link})
+	return nil
+}
+
+func (s *Server) ListLinks() []LinkLedger {
+	links := []LinkLedger{}
+	for _, l := range s.links {
+		links = append(links, *l)
+	}
+	return links
+}
+
+func (s *Server) LinkIndexHandler(w http.ResponseWriter, r *http.Request) {
+	s.Lock()
+	defer s.Unlock()
+
+	c := s.ListLinks()
+
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(c); err != nil {
+		panic(err)
+	}
+}
+
+func (s *Server) LinkCreateHandler(w http.ResponseWriter, r *http.Request) {
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, Error{err.Error()})
+		return
+	}
+
+	var newLink ProtoLink
+	json.Unmarshal(body, &newLink)
+
+	s.Lock()
+	defer s.Unlock()
+
+	nl, err := s.CreateLink(newLink)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, Error{err.Error()})
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	writeJSON(w, nl)
+}
+
+func (s *Server) LinkDeleteHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	ids, ok := vars["id"]
+	if !ok {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, Error{"no ID supplied"})
+		return
+	}
+
+	id, err := strconv.Atoi(ids)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, Error{err.Error()})
+		return
+	}
+
+	s.Lock()
+	defer s.Unlock()
+
+	err = s.DeleteLink(id)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, Error{err.Error()})
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/core/server/link.go
+++ b/core/server/link.go
@@ -38,6 +38,10 @@ func (s *Server) CreateLink(l ProtoLink) (*LinkLedger, error) {
 		Id:     s.GetNextID(),
 	}
 
+	if b.GetParent() != sl.GetParent() {
+		return nil, errors.new("block and source must be in the same group, cannot link")
+	}
+
 	err := b.Block.SetSource(*sl.Source)
 	if err != nil {
 		return nil, err

--- a/core/server/router.go
+++ b/core/server/router.go
@@ -183,6 +183,24 @@ func (s *Server) NewRouter() *mux.Router {
 			"GET",
 			s.LibraryHandler,
 		},
+		Route{
+			"LinkIndex",
+			"/links",
+			"GET",
+			s.LinkIndexHandler,
+		},
+		Route{
+			"LinkCreate",
+			"/links",
+			"POST",
+			s.LinkCreateHandler,
+		},
+		Route{
+			"LinkDelete",
+			"/connections/{id}",
+			"DELETE",
+			s.ConnectionDeleteHandler,
+		},
 	}
 	router := mux.NewRouter().StrictSlash(true)
 	for _, route := range routes {

--- a/core/server/router.go
+++ b/core/server/router.go
@@ -162,7 +162,7 @@ func (s *Server) NewRouter() *mux.Router {
 		Route{
 			"SourceModify",
 			"/sources/{id}",
-			"/PUT",
+			"PUT",
 			s.SourceModifyHandler,
 		},
 		Route{

--- a/core/server/server.go
+++ b/core/server/server.go
@@ -25,14 +25,15 @@ type Server struct {
 	blocks      map[int]*BlockLedger
 	connections map[int]*ConnectionLedger
 	//routes      map[RoutePair]RoutePair
-	stores     map[int]*core.Source
-	library    map[string]core.Spec
-	supervisor *suture.Supervisor
-	lastID     int
-	addSocket  chan *socket
-	delSocket  chan *socket
-	broadcast  chan []byte
-	emitChan   chan []byte
+	stores        map[int]*core.Source
+	library       map[string]core.Spec
+	sourceLibrary map[string]core.NewSource
+	supervisor    *suture.Supervisor
+	lastID        int
+	addSocket     chan *socket
+	delSocket     chan *socket
+	broadcast     chan []byte
+	emitChan      chan []byte
 	sync.Mutex
 }
 
@@ -53,17 +54,19 @@ func NewServer() *Server {
 	connections := make(map[int]*ConnectionLedger)
 	stores := make(map[int]*core.Source)
 	library := core.GetLibrary()
+	sourceLibrary := core.GetSources()
 	parents := make(map[int]int)
 	//routes := make(map[RoutePair]RoutePair)
 	s := &Server{
-		supervisor:  supervisor,
-		lastID:      0,
-		parents:     parents,
-		groups:      groups,
-		blocks:      blocks,
-		connections: connections,
-		library:     library,
-		stores:      stores,
+		supervisor:    supervisor,
+		lastID:        0,
+		parents:       parents,
+		groups:        groups,
+		blocks:        blocks,
+		sourceLibrary: sourceLibrary,
+		connections:   connections,
+		library:       library,
+		stores:        stores,
 		//routes:      routes,
 		addSocket: make(chan *socket),
 		delSocket: make(chan *socket),

--- a/core/server/server.go
+++ b/core/server/server.go
@@ -20,12 +20,11 @@ const (
 
 // The Server maintains a set of handlers that coordinate the creation of Nodes
 type Server struct {
-	groups      map[int]*Group // TODO these maps aren't strictly necessary, but save constantly performing depth first searches
-	parents     map[int]int
-	blocks      map[int]*BlockLedger
-	connections map[int]*ConnectionLedger
-	//routes      map[RoutePair]RoutePair
-	stores        map[int]*core.Source
+	groups        map[int]*Group // TODO these maps aren't strictly necessary, but save constantly performing depth first searches
+	parents       map[int]int
+	blocks        map[int]*BlockLedger
+	connections   map[int]*ConnectionLedger
+	sources       map[int]*core.Source
 	library       map[string]core.Spec
 	sourceLibrary map[string]core.NewSource
 	supervisor    *suture.Supervisor
@@ -42,7 +41,6 @@ func NewServer() *Server {
 	supervisor := suture.NewSimple("st-core")
 	supervisor.ServeBackground()
 	groups := make(map[int]*Group)
-	//groups[0] = NewGroup(0, "root") // this is the top level group
 	groups[0] = &Group{
 		Label:    "root",
 		Id:       0,
@@ -52,11 +50,10 @@ func NewServer() *Server {
 
 	blocks := make(map[int]*BlockLedger)
 	connections := make(map[int]*ConnectionLedger)
-	stores := make(map[int]*core.Source)
+	sources := make(map[int]*core.Source)
 	library := core.GetLibrary()
 	sourceLibrary := core.GetSources()
 	parents := make(map[int]int)
-	//routes := make(map[RoutePair]RoutePair)
 	s := &Server{
 		supervisor:    supervisor,
 		lastID:        0,
@@ -66,7 +63,7 @@ func NewServer() *Server {
 		sourceLibrary: sourceLibrary,
 		connections:   connections,
 		library:       library,
-		stores:        stores,
+		sources:       sources,
 		//routes:      routes,
 		addSocket: make(chan *socket),
 		delSocket: make(chan *socket),

--- a/core/server/server.go
+++ b/core/server/server.go
@@ -16,6 +16,8 @@ const (
 	BLOCK       = "block"
 	GROUP       = "group"
 	GROUP_CHILD = "group_child"
+	SOURCE      = "source"
+	LINK        = "link"
 )
 
 // The Server maintains a set of handlers that coordinate the creation of Nodes
@@ -24,7 +26,8 @@ type Server struct {
 	parents       map[int]int
 	blocks        map[int]*BlockLedger
 	connections   map[int]*ConnectionLedger
-	sources       map[int]*core.Source
+	sources       map[int]*SourceLedger
+	links         map[int]*LinkLedger
 	library       map[string]core.Spec
 	sourceLibrary map[string]core.NewSource
 	supervisor    *suture.Supervisor
@@ -50,7 +53,8 @@ func NewServer() *Server {
 
 	blocks := make(map[int]*BlockLedger)
 	connections := make(map[int]*ConnectionLedger)
-	sources := make(map[int]*core.Source)
+	sources := make(map[int]*SourceLedger)
+	links := make(map[int]*LinkLedger)
 	library := core.GetLibrary()
 	sourceLibrary := core.GetSources()
 	parents := make(map[int]int)
@@ -63,12 +67,12 @@ func NewServer() *Server {
 		sourceLibrary: sourceLibrary,
 		connections:   connections,
 		library:       library,
+		links:         links,
 		sources:       sources,
-		//routes:      routes,
-		addSocket: make(chan *socket),
-		delSocket: make(chan *socket),
-		broadcast: make(chan []byte),
-		emitChan:  make(chan []byte),
+		addSocket:     make(chan *socket),
+		delSocket:     make(chan *socket),
+		broadcast:     make(chan []byte),
+		emitChan:      make(chan []byte),
 	}
 	// ws stuff
 	log.Println("starting websocker handler")

--- a/core/server/sources.go
+++ b/core/server/sources.go
@@ -1,20 +1,33 @@
 package server
 
 import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
 	"net/http"
+	"strconv"
 
+	"github.com/gorilla/mux"
 	"github.com/nytlabs/st-core/core"
 	"github.com/thejerf/suture"
 )
 
 type SourceLedger struct {
-	Label    string              `json:"label"`
-	Type     string              `json:"type"`
-	Id       int                 `json:"id"`
-	Block    *core.Source        `json:"-"`
-	Parent   *Group              `json:"-"`
-	Token    suture.ServiceToken `json:"-"`
-	Position Position            `json:"position"`
+	Label      string              `json:"label"`
+	Type       string              `json:"type"`
+	Id         int                 `json:"id"`
+	Source     *core.Source        `json:"-"`
+	Parent     *Group              `json:"-"`
+	Token      suture.ServiceToken `json:"-"`
+	Position   Position            `json:"position"`
+	Parameters map[string]string   `json:"params"`
+}
+
+type ProtoSource struct {
+	Label    string   `json:"label"`
+	Type     string   `json:"type"`
+	Position Position `json:"position"`
+	Parent   int      `json:"group"`
 }
 
 func (sl *SourceLedger) GetID() int {
@@ -29,13 +42,134 @@ func (sl *SourceLedger) SetParent(group *Group) {
 	sl.Parent = group
 }
 
-func (s *Server) SourceIndexHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Server) ListSources() []SourceLedger {
+	sources := []SourceLedger{}
+	for _, source := range s.sources {
+		sources = append(sources, *source)
+	}
+	return sources
 }
+
+func (s *Server) SourceIndexHandler(w http.ResponseWriter, r *http.Request) {
+	s.Lock()
+	defer s.Unlock()
+
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(s.ListSources()); err != nil {
+		panic(err)
+	}
+}
+
 func (s *Server) SourceHandler(w http.ResponseWriter, r *http.Request) {
 }
+func (s *Server) CreateSource(p ProtoSource) (*SourceLedger, error) {
+	f, ok := s.sourceLibrary[p.Type]
+	if !ok {
+		return nil, errors.New("source type does not exist")
+	}
+
+	source := f()
+
+	sl := &SourceLedger{
+		Label:    p.Label,
+		Position: p.Position,
+		Source:   &source,
+		Type:     p.Type,
+		Id:       s.GetNextID(),
+	}
+
+	sl.Token = s.supervisor.Add(source)
+	s.sources[sl.Id] = sl
+	s.websocketBroadcast(Update{Action: CREATE, Type: SOURCE, Data: sl})
+
+	err := s.AddChildToGroup(p.Parent, sl)
+	if err != nil {
+		return nil, err
+
+	}
+
+	return sl, nil
+}
+
+func (s *Server) DeleteSource(id int) error {
+	source, ok := s.sources[id]
+	if !ok {
+		return errors.New("could not find source")
+	}
+
+	for _, l := range s.links {
+		if l.Source == id {
+			err := s.DeleteLink(l.Id)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	s.DetachChild(source)
+	s.supervisor.Remove(source.Token)
+	s.websocketBroadcast(Update{Action: DELETE, Type: SOURCE, Data: s.sources[id]})
+	delete(s.sources, source.Id)
+	return nil
+}
+
 func (s *Server) SourceCreateHandler(w http.ResponseWriter, r *http.Request) {
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, Error{"could not read request body"})
+		return
+	}
+
+	var m ProtoSource
+	err = json.Unmarshal(body, &m)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, Error{"no ID supplied"})
+		return
+	}
+
+	s.Lock()
+	defer s.Unlock()
+
+	b, err := s.CreateSource(m)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, Error{err.Error()})
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	writeJSON(w, b)
 }
 func (s *Server) SourceModifyHandler(w http.ResponseWriter, r *http.Request) {
 }
 func (s *Server) SourceDeleteHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	ids, ok := vars["id"]
+	if !ok {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, Error{"no ID supplied"})
+		return
+	}
+
+	id, err := strconv.Atoi(ids)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, Error{err.Error()})
+		return
+	}
+
+	s.Lock()
+	defer s.Unlock()
+
+	err = s.DeleteSource(id)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, Error{err.Error()})
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/core/server/sources.go
+++ b/core/server/sources.go
@@ -1,6 +1,33 @@
 package server
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/nytlabs/st-core/core"
+	"github.com/thejerf/suture"
+)
+
+type SourceLedger struct {
+	Label    string              `json:"label"`
+	Type     string              `json:"type"`
+	Id       int                 `json:"id"`
+	Block    *core.Source        `json:"-"`
+	Parent   *Group              `json:"-"`
+	Token    suture.ServiceToken `json:"-"`
+	Position Position            `json:"position"`
+}
+
+func (sl *SourceLedger) GetID() int {
+	return sl.Id
+}
+
+func (sl *SourceLedger) GetParent() *Group {
+	return sl.Parent
+}
+
+func (sl *SourceLedger) SetParent(group *Group) {
+	sl.Parent = group
+}
 
 func (s *Server) SourceIndexHandler(w http.ResponseWriter, r *http.Request) {
 }

--- a/core/sources.go
+++ b/core/sources.go
@@ -1,0 +1,19 @@
+package core
+
+/*var SourceNames = map[sourceType]string{
+	NONE:      "None",
+	KEY_VALUE: "Key-Value",
+	STREAM:    "Stream",
+	PRIORITY:  "Priority Queue",
+	ARRAY:     "Array",
+	VALUE:     "Value",
+}*/
+
+type NewSource func() Source
+
+func GetSources() map[string]NewSource {
+	return map[string]NewSource{
+		"keyvalue": NewKeyValue,
+		"stream":   NewStream,
+	}
+}

--- a/core/stream.go
+++ b/core/stream.go
@@ -47,7 +47,7 @@ func (s *Stream) Describe() map[string]string {
 	}
 }
 
-func NewStream() *Stream {
+func NewStream() Source {
 	out := make(chan Message)
 	stream := Stream{
 		quit:        make(chan bool),

--- a/core/stream.go
+++ b/core/stream.go
@@ -49,12 +49,12 @@ func (s *Stream) Describe() map[string]string {
 
 func NewStream() Source {
 	out := make(chan Message)
-	stream := Stream{
+	stream := &Stream{
 		quit:        make(chan bool),
 		Out:         out,
 		maxInFlight: "10",
 	}
-	return &stream
+	return stream
 }
 
 func (s Stream) Serve() {

--- a/core/stream.go
+++ b/core/stream.go
@@ -42,7 +42,7 @@ func (s *Stream) Describe() map[string]string {
 	return map[string]string{
 		"topic":       s.topic,
 		"channel":     s.channel,
-		"lookupAddr":  s.lookupdAddr,
+		"lookupdAddr": s.lookupdAddr,
 		"maxInFlight": s.maxInFlight,
 	}
 }


### PR DESCRIPTION
API endpoints added:
```
POST   /links
GET    /links
DELETE /links/{ID}
POST   /sources
GET    /sources
PUT    /sources/{ID}
DELETE /sources/{ID}
PUT    /groups/{ID}/position
```

sources and links also should appropriately be importable/exportable.

also:
- there was a bug in stream.go in which it improperly described itself (typo)
- there was a bug in export that did not export cross-group connections.
- made it so that Block.SetSource returns an error if the source is incompatible 
- added GetSources(), which works similarly to GetLibrary()