### PR TITLE
API bug fixes

### DIFF
--- a/core/block.go
+++ b/core/block.go
@@ -149,7 +149,7 @@ func (b *Block) GetSource() Source {
 func (b *Block) SetSource(s Source) error {
 	returnVal := make(chan error, 1)
 	b.routing.InterruptChan <- func() bool {
-		if s.GetType() != b.sourceType {
+		if s != nil && s.GetType() != b.sourceType {
 			returnVal <- errors.New("invalid source type for this block")
 			return true
 		}

--- a/core/keyvalue.go
+++ b/core/keyvalue.go
@@ -2,6 +2,14 @@ package core
 
 import "sync"
 
+func KeyValueSource() SourceSpec {
+	return SourceSpec{
+		Name: "key-value",
+		Type: KEY_VALUE,
+		New:  NewKeyValue,
+	}
+}
+
 func NewKeyValue() Source {
 	return &KeyValue{
 		kv:   make(map[string]Message),

--- a/core/sources.go
+++ b/core/sources.go
@@ -1,19 +1,16 @@
 package core
 
-/*var SourceNames = map[sourceType]string{
-	NONE:      "None",
-	KEY_VALUE: "Key-Value",
-	STREAM:    "Stream",
-	PRIORITY:  "Priority Queue",
-	ARRAY:     "Array",
-	VALUE:     "Value",
-}*/
-
-type NewSource func() Source
-
-func GetSources() map[string]NewSource {
-	return map[string]NewSource{
-		"keyvalue": NewKeyValue,
-		"stream":   NewStream,
+func GetSources() map[string]SourceSpec {
+	sources := []SourceSpec{
+		StreamSource(),
+		KeyValueSource(),
 	}
+
+	library := make(map[string]SourceSpec)
+
+	for _, s := range sources {
+		library[s.Name] = s
+	}
+
+	return library
 }

--- a/core/stream.go
+++ b/core/stream.go
@@ -8,6 +8,14 @@ import (
 	"github.com/bitly/go-nsq"
 )
 
+func StreamSource() SourceSpec {
+	return SourceSpec{
+		Name: "stream",
+		Type: STREAM,
+		New:  NewStream,
+	}
+}
+
 type Stream struct {
 	quit        chan bool
 	Out         chan Message // this channel is used by any block that would like to receive messages

--- a/core/types.go
+++ b/core/types.go
@@ -88,6 +88,16 @@ type Output struct {
 	Connections map[Connection]struct{} `json:"-"`
 }
 
+// A SourceSpec defines a source's name and type
+type SourceSpec struct {
+	Name string
+	Type int
+	New  SourceFunc
+}
+
+// A function that creates a source
+type SourceFunc func() Source
+
 // A ManifestPair is a unique reference to an Output/Connection pair
 type ManifestPair struct {
 	int

--- a/core/types.go
+++ b/core/types.go
@@ -2,12 +2,7 @@
 // one another by passing Messages.
 package core
 
-import (
-	"encoding/json"
-	"sync"
-
-	"github.com/nikhan/go-fetch"
-)
+import "sync"
 
 const (
 	NONE = iota
@@ -62,23 +57,6 @@ type Input struct {
 	Name  string
 	Value interface{}
 	C     chan Message
-}
-
-func (r Input) MarshalJSON() ([]byte, error) {
-	out := make(map[string]interface{})
-	value := make(map[string]interface{})
-	out["name"] = r.Name
-
-	switch q := r.Value.(type) {
-	case *fetch.Query:
-		value["fetch"] = q.String()
-	default:
-		value["json"] = q
-	}
-
-	out["value"] = value
-
-	return json.Marshal(out)
 }
 
 // An Output holds a set of Connections. Each Connection refers to a Input.C. Every outbound

--- a/server/block.go
+++ b/server/block.go
@@ -77,7 +77,36 @@ func (s *Server) BlockIndexHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) BlockHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	ids, ok := vars["id"]
+	if !ok {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, Error{"no ID supplied"})
+		return
+	}
+
+	id, err := strconv.Atoi(ids)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, Error{err.Error()})
+		return
+	}
+
+	s.Lock()
+	defer s.Unlock()
+
+	b, ok := s.blocks[id]
+	if !ok {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, Error{"could not find block"})
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	writeJSON(w, b)
+	return
 }
+
 func (s *Server) BlockModifyPositionHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	ids, ok := vars["id"]

--- a/server/library.go
+++ b/server/library.go
@@ -12,7 +12,7 @@ type LibraryEntry struct {
 	// type if we need that later
 }
 
-func (s *Server) LibraryHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Server) BlockLibraryHandler(w http.ResponseWriter, r *http.Request) {
 	s.Lock()
 	defer s.Unlock()
 
@@ -22,6 +22,26 @@ func (s *Server) LibraryHandler(w http.ResponseWriter, r *http.Request) {
 		l = append(l, LibraryEntry{
 			v.Name,
 			int(v.Source),
+		})
+	}
+
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(l); err != nil {
+		panic(err)
+	}
+}
+
+func (s *Server) SourceLibraryHandler(w http.ResponseWriter, r *http.Request) {
+	s.Lock()
+	defer s.Unlock()
+
+	l := []LibraryEntry{}
+
+	for _, v := range s.sourceLibrary {
+		l = append(l, LibraryEntry{
+			v.Name,
+			v.Type,
 		})
 	}
 

--- a/server/router.go
+++ b/server/router.go
@@ -203,9 +203,9 @@ func (s *Server) NewRouter() *mux.Router {
 		},
 		Route{
 			"LinkDelete",
-			"/connections/{id}",
+			"/links/{id}",
 			"DELETE",
-			s.ConnectionDeleteHandler,
+			s.LinkDeleteHandler,
 		},
 	}
 	router := mux.NewRouter().StrictSlash(true)

--- a/server/router.go
+++ b/server/router.go
@@ -22,6 +22,18 @@ func (s *Server) NewRouter() *mux.Router {
 			s.UpdateSocketHandler,
 		},
 		Route{
+			"BlockLibrary",
+			"/blocks/library",
+			"GET",
+			s.BlockLibraryHandler,
+		},
+		Route{
+			"SourceLibrary",
+			"/sources/library",
+			"GET",
+			s.SourceLibraryHandler,
+		},
+		Route{
 			"GroupIndex",
 			"/groups",
 			"GET",
@@ -176,12 +188,6 @@ func (s *Server) NewRouter() *mux.Router {
 			"/sources/{id}",
 			"DELETE",
 			s.SourceDeleteHandler,
-		},
-		Route{
-			"Library",
-			"/library",
-			"GET",
-			s.LibraryHandler,
 		},
 		Route{
 			"LinkIndex",

--- a/server/server.go
+++ b/server/server.go
@@ -29,7 +29,7 @@ type Server struct {
 	sources       map[int]*SourceLedger
 	links         map[int]*LinkLedger
 	library       map[string]core.Spec
-	sourceLibrary map[string]core.NewSource
+	sourceLibrary map[string]core.SourceSpec
 	supervisor    *suture.Supervisor
 	lastID        int
 	addSocket     chan *socket

--- a/server/source.go
+++ b/server/source.go
@@ -69,7 +69,7 @@ func (s *Server) CreateSource(p ProtoSource) (*SourceLedger, error) {
 		return nil, errors.New("source type does not exist")
 	}
 
-	source := f()
+	source := f.New()
 
 	sl := &SourceLedger{
 		Label:    p.Label,


### PR DESCRIPTION
 39ac102 - added `GET /blocks/{id}`
 55dbb6c - removed unused marshaling code from routes
 4bbaaf3 - make sources self-describing like blocks, added new type SourceSpec
 19e95cf - moved library to `/blocks/library` and `/sources/library`
 fb71e3f - link deletion was broken, this fixes it