### PR TITLE
making error exportable

### DIFF
--- a/core/library.go
+++ b/core/library.go
@@ -9,17 +9,17 @@ import (
 )
 
 type stcoreError struct {
-	s string
+	S string `json:"core"`
 }
 
 func (e *stcoreError) Error() string {
-	log.Println(e.s)
-	return e.s
+	log.Println(e.S)
+	return e.S
 }
 
 func NewError(s string) *stcoreError {
 	return &stcoreError{
-		s: s,
+		S: s,
 	}
 }
 

--- a/server/connection.go
+++ b/server/connection.go
@@ -80,7 +80,7 @@ func (s *Server) CreateConnection(newConn ProtoConnection) (*ConnectionLedger, e
 		return nil, errors.New("source block does not exist")
 	}
 
-	target := s.blocks[newConn.Target.Id]
+	target, ok := s.blocks[newConn.Target.Id]
 	if !ok {
 		return nil, errors.New("target block does not exist")
 	}


### PR DESCRIPTION
the errors didn't have an exported field so nothing would show up in the log. That's fixed now. 