### PR TITLE
important fix for broadcast

### DIFF
--- a/core/block.go
+++ b/core/block.go
@@ -304,6 +304,13 @@ func (b *Block) process() Interrupt {
 // broadcast the kernel output to all connections on all outputs.
 func (b *Block) broadcast() Interrupt {
 	for id, out := range b.routing.Outputs {
+		// if the output key is not present in the output map, then we
+		// don't deliver any message
+		_, ok := b.state.outputValues[RouteIndex(id)]
+		if !ok {
+			continue
+		}
+
 		// if there no connection for this output then wait until there
 		// is one. that means we have to wait for an interrupt.
 		if len(out.Connections) == 0 {

--- a/core/library.go
+++ b/core/library.go
@@ -207,10 +207,8 @@ func Latch() Spec {
 			}
 			if controlSignal {
 				out[0] = in[0]
-				out[1] = nil
 			} else {
 				out[1] = in[0]
-				out[0] = nil
 			}
 			return nil
 		},


### PR DESCRIPTION
this makes it so that if the key isn't set in the output map in a kernel, then we don't broadcast a message. Setting the key to nil was making it so that the Latch simply broadcasted NIL, not no message. 