### PR TITLE
merge block

### DIFF
--- a/core/block_test.go
+++ b/core/block_test.go
@@ -289,7 +289,6 @@ func TestMerge(t *testing.T) {
 			log.Println(string(ex))
 			t.Error("merge did not return the expected map")
 		}
-
 	}
 
 	// simple test

--- a/core/core_blocks.go
+++ b/core/core_blocks.go
@@ -228,8 +228,17 @@ func Merge() Spec {
 		Outputs: []Pin{Pin{"out", OBJECT}},
 		Kernel: func(in, out, internal MessageMap, s Source, i chan Interrupt) Interrupt {
 			result := make(map[string]interface{})
-			mergo.Merge(&result, in[0])
-			mergo.Merge(&result, in[1])
+			var err error
+			err = mergo.Merge(&result, in[0])
+			if err != nil {
+				out[0] = err
+				return nil
+			}
+			err = mergo.Merge(&result, in[1])
+			if err != nil {
+				out[0] = err
+				return nil
+			}
 			out[0] = result
 			return nil
 		},

--- a/core/core_blocks.go
+++ b/core/core_blocks.go
@@ -235,7 +235,10 @@ func Merge() Spec {
 				out[0] = NewError("Merge requires an object")
 				return nil
 			}
-			result := o1
+			result := make(map[string]interface{})
+			for k, v := range o1 {
+				result[k] = v
+			}
 			for k, v := range o0 {
 				result[k] = v
 			}

--- a/core/core_blocks.go
+++ b/core/core_blocks.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"math"
 	"time"
+
+	"github.com/imdario/mergo"
 )
 
 func First() Spec {
@@ -215,7 +217,7 @@ func Append() Spec {
 	}
 }
 
-// Merge takes merges two objects, favouring the first input to resolve conflicts
+// Merge recursively merges two objects, favouring the first input to resolve conflicts
 func Merge() Spec {
 	return Spec{
 		Name: "merge",
@@ -225,23 +227,9 @@ func Merge() Spec {
 		},
 		Outputs: []Pin{Pin{"out", OBJECT}},
 		Kernel: func(in, out, internal MessageMap, s Source, i chan Interrupt) Interrupt {
-			o0, ok := in[0].(map[string]interface{})
-			if !ok {
-				out[0] = NewError("Merge requires an object")
-				return nil
-			}
-			o1, ok := in[1].(map[string]interface{})
-			if !ok {
-				out[0] = NewError("Merge requires an object")
-				return nil
-			}
 			result := make(map[string]interface{})
-			for k, v := range o1 {
-				result[k] = v
-			}
-			for k, v := range o0 {
-				result[k] = v
-			}
+			mergo.Merge(&result, in[0])
+			mergo.Merge(&result, in[1])
 			out[0] = result
 			return nil
 		},

--- a/core/core_blocks.go
+++ b/core/core_blocks.go
@@ -215,6 +215,36 @@ func Append() Spec {
 	}
 }
 
+// Merge takes merges two objects, favouring the first input to resolve conflicts
+func Merge() Spec {
+	return Spec{
+		Name: "merge",
+		Inputs: []Pin{
+			Pin{"in", OBJECT},
+			Pin{"in", OBJECT},
+		},
+		Outputs: []Pin{Pin{"out", OBJECT}},
+		Kernel: func(in, out, internal MessageMap, s Source, i chan Interrupt) Interrupt {
+			o0, ok := in[0].(map[string]interface{})
+			if !ok {
+				out[0] = NewError("Merge requires an object")
+				return nil
+			}
+			o1, ok := in[1].(map[string]interface{})
+			if !ok {
+				out[0] = NewError("Merge requires an object")
+				return nil
+			}
+			result := o1
+			for k, v := range o0 {
+				result[k] = v
+			}
+			out[0] = result
+			return nil
+		},
+	}
+}
+
 // Addition returns the sum of the addenda
 func Addition() Spec {
 	return Spec{

--- a/core/library.go
+++ b/core/library.go
@@ -34,6 +34,7 @@ func GetLibrary() map[string]Spec {
 		Tail(),
 		Head(),
 		Pusher(),
+		Merge(),
 
 		// monads
 		Exp(),


### PR DESCRIPTION
this is a simple merge block. Accepts two objects, favouring the first for breaking ties. 

This is, I think, all that's needed to allow a value to act as a key-value store. Still not sure if this warrants removing the first class KeyValue Store.