### PR TITLE
making block sources visible to client

### DIFF
--- a/core/types.go
+++ b/core/types.go
@@ -2,7 +2,10 @@
 // one another by passing Messages.
 package core
 
-import "sync"
+import (
+	"errors"
+	"sync"
+)
 
 const (
 	NONE = iota
@@ -38,6 +41,45 @@ type RouteIndex int
 
 // SourceType is used to indicate what kind of source a block can connect to
 type SourceType int
+
+func (s *SourceType) UnmarshalJSON(data []byte) error {
+	st := string(data)
+	switch st {
+	case `null`:
+		*s = SourceType(NONE)
+	case `"key_value"`:
+		*s = SourceType(KEY_VALUE)
+	case `"stream"`:
+		*s = SourceType(STREAM)
+	case `"list"`:
+		*s = SourceType(LIST)
+	case `"value"`:
+		*s = SourceType(VALUE_PRIMITIVE)
+	case `"priority"`:
+		*s = SourceType(PRIORITY)
+	default:
+		return errors.New("Error unmarshalling source type")
+	}
+	return nil
+}
+
+func (s SourceType) MarshalJSON() ([]byte, error) {
+	switch s {
+	case NONE:
+		return []byte(`null`), nil
+	case KEY_VALUE:
+		return []byte(`"key_value"`), nil
+	case STREAM:
+		return []byte(`"stream"`), nil
+	case LIST:
+		return []byte(`"list"`), nil
+	case VALUE_PRIMITIVE:
+		return []byte(`"value"`), nil
+	case PRIORITY:
+		return []byte(`"priority"`), nil
+	}
+	return nil, errors.New("Unknown source type")
+}
 
 // Connections are used to connect blocks together
 type Connection chan Message
@@ -94,7 +136,7 @@ type Output struct {
 // A SourceSpec defines a source's name and type
 type SourceSpec struct {
 	Name string
-	Type int
+	Type SourceType
 	New  SourceFunc
 }
 

--- a/server/block.go
+++ b/server/block.go
@@ -24,15 +24,16 @@ type ProtoBlock struct {
 }
 
 type BlockLedger struct {
-	Label       string        `json:"label"`
-	Type        string        `json:"type"`
-	Id          int           `json:"id"`
-	Block       *core.Block   `json:"-"`
-	Parent      *Group        `json:"-"`
-	Composition int           `json:"composition,omitempty"`
-	Inputs      []core.Input  `json:"inputs"`
-	Outputs     []core.Output `json:"outputs"`
-	Position    Position      `json:"position"`
+	Label       string          `json:"label"`
+	Type        string          `json:"type"`
+	Id          int             `json:"id"`
+	Block       *core.Block     `json:"-"`
+	Parent      *Group          `json:"-"`
+	Composition int             `json:"composition,omitempty"`
+	Inputs      []core.Input    `json:"inputs"`
+	Outputs     []core.Output   `json:"outputs"`
+	Source      core.SourceType `json:"source"`
+	Position    Position        `json:"position"`
 }
 
 func (bl *BlockLedger) GetID() int {
@@ -141,6 +142,7 @@ func (s *Server) CreateBlock(p ProtoBlock) (*BlockLedger, error) {
 		Position: p.Position,
 		Type:     p.Type,
 		Block:    block,
+		Source:   blockSpec.Source,
 		Id:       s.GetNextID(),
 	}
 

--- a/server/library.go
+++ b/server/library.go
@@ -3,12 +3,14 @@ package server
 import (
 	"encoding/json"
 	"net/http"
+
+	"github.com/nytlabs/st-core/core"
 )
 
 // naming confusion between "name" and "type" ~_~
 type LibraryEntry struct {
-	Type   string `json:"type"`
-	Source int    `json:"source"`
+	Type   string          `json:"type"`
+	Source core.SourceType `json:"source"`
 	// type if we need that later
 }
 
@@ -21,7 +23,7 @@ func (s *Server) BlockLibraryHandler(w http.ResponseWriter, r *http.Request) {
 	for _, v := range s.library {
 		l = append(l, LibraryEntry{
 			v.Name,
-			int(v.Source),
+			v.Source,
 		})
 	}
 

--- a/static/js/model/model.js
+++ b/static/js/model/model.js
@@ -97,7 +97,6 @@ var app = app || {};
             'blocks/library',
             null,
             function(req) {
-                console.log(req.response);
                 this.blockLibrary = JSON.parse(req.response);
             }.bind(this)
         )

--- a/static/js/model/model.js
+++ b/static/js/model/model.js
@@ -97,6 +97,7 @@ var app = app || {};
             'blocks/library',
             null,
             function(req) {
+                console.log(req.response);
                 this.blockLibrary = JSON.parse(req.response);
             }.bind(this)
         )


### PR DESCRIPTION
each block json that is sent to the client now includes what kind of source it requires to be connected to, if necessary. 