### PR TITLE
fixing source/group issue

### DIFF
--- a/server/link.go
+++ b/server/link.go
@@ -44,10 +44,6 @@ func (s *Server) CreateLink(l ProtoLink) (*LinkLedger, error) {
 	link.Source.Id = l.Source.Id
 	link.Block.Id = l.Block.Id
 
-	if b.GetParent() != sl.GetParent() {
-		return nil, errors.New("block and source must be in the same group, cannot link")
-	}
-
 	err := b.Block.SetSource(sl.Source)
 	if err != nil {
 		return nil, err

--- a/static/js/model/group.js
+++ b/static/js/model/group.js
@@ -79,6 +79,7 @@ var app = app || {};
                     index: r.index,
                     displayIndex: displayIndex[r.direction]++,
                     parentNode: this,
+                    source: r.source
                 })
             }.bind(this))
         }.bind(this))


### PR DESCRIPTION
for some we had it such that blocks needed to be in the same group as the connected source. this PR makes that no longer the case. 