### PR TITLE
send fix (attempt at #92)

### DIFF
--- a/core/block.go
+++ b/core/block.go
@@ -377,7 +377,7 @@ func (b *Block) deliver(ensure bool) (bool, Interrupt) {
 // broadcast the kernel output to all connections on all outputs.
 func (b *Block) broadcast() Interrupt {
 	// we attempt to deliver twice. the first with a non-blocking send, and
-	// secondly, a blocking send. If the non-blocking send fails on all pins,
+	// secondly, a blocking send. If the non-blocking send fails at least once,
 	// we revert to a blocking send state.
 	done, i := b.deliver(false)
 	if i != nil {

--- a/core/block.go
+++ b/core/block.go
@@ -313,8 +313,12 @@ func (b *Block) process() Interrupt {
 	return nil
 }
 
-// broadcast the kernel output to all connections on all outputs.
-func (b *Block) broadcast() Interrupt {
+func (b *Block) deliver(ensure bool) (bool, Interrupt) {
+	total := 0
+	for _, out := range b.routing.Outputs {
+		total += len(out.Connections)
+	}
+
 	for id, out := range b.routing.Outputs {
 		// if the output key is not present in the output map, then we
 		// don't deliver any message
@@ -328,7 +332,7 @@ func (b *Block) broadcast() Interrupt {
 		if len(out.Connections) == 0 {
 			select {
 			case f := <-b.routing.InterruptChan:
-				return f
+				return len(b.state.manifest) == total, f
 			}
 		}
 		for c, _ := range out.Connections {
@@ -340,16 +344,56 @@ func (b *Block) broadcast() Interrupt {
 				continue
 			}
 
-			select {
-			case c <- b.state.outputValues[RouteIndex(id)]:
-				// set that we have delivered the message.
-				b.state.manifest[m] = struct{}{}
-			case f := <-b.routing.InterruptChan:
-				return f
+			// ensure is a flag that toggles between a blocking send and a non-
+			// blocking send. in some circumstances, connections may get
+			// "crossed". When this happens, a connection may block the send
+			// for another connection on the same broadcast pin. This can
+			// happen when a single broadcast pin may attempt to deliver to two
+			// separate inputs on a single block. Because a block receives in
+			// order, the broadcasting pin may attempt to send to a pin that is
+			// not currently in a receive state. This results in eternal
+			// blocking.
+			if ensure {
+				select {
+				case c <- b.state.outputValues[RouteIndex(id)]:
+					// set that we have delivered the message.
+					b.state.manifest[m] = struct{}{}
+				case f := <-b.routing.InterruptChan:
+					return len(b.state.manifest) == total, f
+				}
+			} else {
+				select {
+				case c <- b.state.outputValues[RouteIndex(id)]:
+					// set that we have delivered the message.
+					b.state.manifest[m] = struct{}{}
+				default:
+				}
 			}
 		}
-
 	}
+	return len(b.state.manifest) == total, nil
+}
+
+// broadcast the kernel output to all connections on all outputs.
+func (b *Block) broadcast() Interrupt {
+	// we attempt to deliver twice. the first with a non-blocking send, and
+	// secondly, a blocking send. If the non-blocking send fails on all pins,
+	// we revert to a blocking send state.
+	done, i := b.deliver(false)
+	if i != nil {
+		return i
+	}
+	if done {
+		return nil
+	}
+	done, i = b.deliver(true)
+	if i != nil {
+		return i
+	}
+	if !done {
+		panic("cataclymsic error, we should never get here")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Submitted for debate. This may fix the issue in #92. 

To test, in current master, run this pattern:
```
{"blocks":[{"label":"","type":"+","id":1,"inputs":[{"name":"x","value":null,"type":"number"},{"name":"y","value":{"data":1},"type":"number"}],"outputs":[{"name":"x+y","type":"number"}],"source":null,"position":{"x":292,"y":166}},{"label":"","type":"delay","id":2,"inputs":[{"name":"in","value":null,"type":"any"},{"name":"duration","value":{"data":"1s"},"type":"string"}],"outputs":[{"name":"out","type":"any"}],"source":null,"position":{"x":423,"y":154}},{"label":"","type":"log","id":3,"inputs":[{"name":"log","value":null,"type":"any"}],"outputs":[],"source":null,"position":{"x":644,"y":302}},{"label":"","type":"first","id":4,"inputs":[{"name":"in","value":null,"type":"any"}],"outputs":[{"name":"first","type":"any"}],"source":null,"position":{"x":102,"y":267}},{"label":"","type":"identity","id":5,"inputs":[{"name":"in","value":null,"type":"any"}],"outputs":[{"name":"out","type":"any"}],"source":null,"position":{"x":277,"y":363}},{"label":"","type":"latch","id":6,"inputs":[{"name":"in","value":null,"type":"any"},{"name":"ctrl","value":null,"type":"boolean"}],"outputs":[{"name":"true","type":"any"},{"name":"false","type":"any"}],"source":null,"position":{"x":186,"y":183}},{"label":"","type":"identity","id":7,"inputs":[{"name":"in","value":{"data":0},"type":"any"}],"outputs":[{"name":"out","type":"any"}],"source":null,"position":{"x":43,"y":104}},{"label":"","type":"gate","id":8,"inputs":[{"name":"in","value":null,"type":"any"},{"name":"ctrl","value":null,"type":"any"}],"outputs":[{"name":"out","type":"any"}],"source":null,"position":{"x":529,"y":242}}],"sources":[],"links":[],"connections":[{"from":{"id":5,"route":0},"to":{"id":1,"route":0},"id":15},{"from":{"id":6,"route":0},"to":{"id":1,"route":0},"id":16},{"from":{"id":4,"route":0},"to":{"id":6,"route":1},"id":17},{"from":{"id":7,"route":0},"to":{"id":4,"route":0},"id":18},{"from":{"id":1,"route":0},"to":{"id":5,"route":0},"id":19},{"from":{"id":7,"route":0},"to":{"id":6,"route":0},"id":20},{"from":{"id":1,"route":0},"to":{"id":2,"route":0},"id":21},{"from":{"id":1,"route":0},"to":{"id":8,"route":1},"id":22},{"from":{"id":2,"route":0},"to":{"id":8,"route":0},"id":29},{"from":{"id":8,"route":0},"to":{"id":3,"route":0},"id":30}],"groups":[]}
```
it emits an increasing number every second. At some point it will block forever (usually by 3 or 4 for me, entropy depending). 

this PR should fix that. The pass of the non-blocking send makes me nervous, however, my understanding after looking into it is that if the receiving channel is free, a non-blocking send is guaranteed to deliver. More details of the issue in comments in the commit.

Been running the tangle-fixer at infinite pressure for hours now, no "cataclymsic" panics so far.