### PR TITLE
state display for routes

### DIFF
--- a/core/block.go
+++ b/core/block.go
@@ -244,10 +244,13 @@ func (b *Block) Stop() {
 // wait and listen for all kernel inputs to be filled.
 func (b *Block) receive() Interrupt {
 	for id, input := range b.routing.Inputs {
-		b.Monitor <- MonitorMessage{
+		select {
+		case b.Monitor <- MonitorMessage{
 			BI_RECEIVE,
 			id,
-			time.Now(),
+			//			time.Now(),
+		}:
+		default:
 		}
 
 		//if we have already received a value on this input, skip.
@@ -272,10 +275,13 @@ func (b *Block) receive() Interrupt {
 
 // run kernel on inputs, produce outputs
 func (b *Block) process() Interrupt {
-	b.Monitor <- MonitorMessage{
+	select {
+	case b.Monitor <- MonitorMessage{
 		BI_KERNEL,
 		nil,
-		time.Now(),
+		//		time.Now(),
+	}:
+	default:
 	}
 
 	if b.state.Processed == true {
@@ -327,10 +333,13 @@ func (b *Block) process() Interrupt {
 // broadcast the kernel output to all connections on all outputs.
 func (b *Block) broadcast() Interrupt {
 	for id, out := range b.routing.Outputs {
-		b.Monitor <- MonitorMessage{
+		select {
+		case b.Monitor <- MonitorMessage{
 			BI_BROADCAST,
 			id,
-			time.Now(),
+			//			time.Now(),
+		}:
+		default:
 		}
 
 		// if the output key is not present in the output map, then we

--- a/core/block.go
+++ b/core/block.go
@@ -244,13 +244,9 @@ func (b *Block) Stop() {
 // wait and listen for all kernel inputs to be filled.
 func (b *Block) receive() Interrupt {
 	for id, input := range b.routing.Inputs {
-		select {
-		case b.Monitor <- MonitorMessage{
+		b.Monitor <- MonitorMessage{
 			BI_RECEIVE,
 			id,
-			//			time.Now(),
-		}:
-		default:
 		}
 
 		//if we have already received a value on this input, skip.
@@ -275,13 +271,9 @@ func (b *Block) receive() Interrupt {
 
 // run kernel on inputs, produce outputs
 func (b *Block) process() Interrupt {
-	select {
-	case b.Monitor <- MonitorMessage{
+	b.Monitor <- MonitorMessage{
 		BI_KERNEL,
 		nil,
-		//		time.Now(),
-	}:
-	default:
 	}
 
 	if b.state.Processed == true {
@@ -337,13 +329,9 @@ func (b *Block) deliver(ensure bool) (bool, Interrupt) {
 	}
 
 	for id, out := range b.routing.Outputs {
-		select {
-		case b.Monitor <- MonitorMessage{
+		b.Monitor <- MonitorMessage{
 			BI_BROADCAST,
 			id,
-			//			time.Now(),
-		}:
-		default:
 		}
 
 		// if the output key is not present in the output map, then we

--- a/core/sources_test.go
+++ b/core/sources_test.go
@@ -23,6 +23,10 @@ func TestList(t *testing.T) {
 		"listDump":   NewBlock(library["listDump"]),
 	}
 
+	for _, v := range blocks {
+		go DummyMonitor(v.Monitor)
+	}
+
 	out := make(chan Message)
 	for name, b := range blocks {
 		log.Println("testing", name)
@@ -124,6 +128,10 @@ func TestValuePrimitive(t *testing.T) {
 		"valueSet": NewBlock(library["valueSet"]),
 	}
 
+	for _, v := range blocks {
+		go DummyMonitor(v.Monitor)
+	}
+
 	out := make(chan Message)
 	for name, b := range blocks {
 		log.Println("testing", name)
@@ -170,6 +178,10 @@ func TestPriorityQueue(t *testing.T) {
 		"pqPop":  NewBlock(library["pqPop"]),
 		"pqPeek": NewBlock(library["pqPeek"]),
 		"pqLen":  NewBlock(library["pqLen"]),
+	}
+
+	for _, v := range blocks {
+		go DummyMonitor(v.Monitor)
 	}
 
 	out := make(chan Message)

--- a/core/types.go
+++ b/core/types.go
@@ -37,22 +37,25 @@ const (
 type BlockInfo uint8
 
 const (
-	BI_BLOCKED BlockInfo = iota
-	BI_UNBLOCKED
-	BI_CRANK
+	BI_RUNNING BlockInfo = iota
 	BI_ERROR
+	BI_RECEIVE
+	BI_BROADCAST
+	BI_KERNEL
 )
 
 func (ba BlockInfo) MarshalJSON() ([]byte, error) {
 	switch ba {
-	case BI_BLOCKED:
-		return []byte(`"blocked"`), nil
-	case BI_UNBLOCKED:
-		return []byte(`"unblocked"`), nil
-	case BI_CRANK:
-		return []byte(`"crank"`), nil
+	case BI_RUNNING:
+		return []byte(`"running"`), nil
 	case BI_ERROR:
 		return []byte(`"error"`), nil
+	case BI_RECEIVE:
+		return []byte(`"receive"`), nil
+	case BI_BROADCAST:
+		return []byte(`"broadcast"`), nil
+	case BI_KERNEL:
+		return []byte(`"kernel"`), nil
 	}
 
 	return nil, errors.New("could not marshal BlockAlert")

--- a/core/types.go
+++ b/core/types.go
@@ -242,5 +242,5 @@ type Block struct {
 type MonitorMessage struct {
 	Type BlockInfo   `json:"type"`
 	Data interface{} `json:"data,omitempty"`
-	Time time.Time   `json:"time"`
+	//	Time time.Time   `json:"time"`
 }

--- a/core/types.go
+++ b/core/types.go
@@ -242,5 +242,4 @@ type Block struct {
 type MonitorMessage struct {
 	Type BlockInfo   `json:"type"`
 	Data interface{} `json:"data,omitempty"`
-	//	Time time.Time   `json:"time"`
 }

--- a/core/types.go
+++ b/core/types.go
@@ -37,19 +37,22 @@ const (
 type BlockInfo uint8
 
 const (
-	BLOCKED BlockInfo = iota
-	UNBLOCKED
-	CRANK
+	BI_BLOCKED BlockInfo = iota
+	BI_UNBLOCKED
+	BI_CRANK
+	BI_ERROR
 )
 
 func (ba BlockInfo) MarshalJSON() ([]byte, error) {
 	switch ba {
-	case BLOCKED:
+	case BI_BLOCKED:
 		return []byte(`"blocked"`), nil
-	case UNBLOCKED:
+	case BI_UNBLOCKED:
 		return []byte(`"unblocked"`), nil
-	case CRANK:
+	case BI_CRANK:
 		return []byte(`"crank"`), nil
+	case BI_ERROR:
+		return []byte(`"error"`), nil
 	}
 
 	return nil, errors.New("could not marshal BlockAlert")
@@ -228,7 +231,13 @@ type Block struct {
 	routing    BlockRouting
 	kernel     Kernel
 	sourceType SourceType
-	Monitor    chan time.Time
+	Monitor    chan MonitorMessage
 	lastCrank  time.Time
 	//blockageTimer *time.Timer
+}
+
+type MonitorMessage struct {
+	Type BlockInfo   `json:"type"`
+	Data interface{} `json:"data,omitempty"`
+	Time time.Time   `json:"time"`
 }

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -22,9 +22,10 @@ import (
 // every block ges a monitor by default. an optimizing step may be to disable
 // it by default, and affording the querying of state by some API handle.
 //
-// in that capacity, the state should live in core.Block, and MonitorMux would
-// simply use a mutex to transmit it, instead of any continous channel traffic
-// from block to Monitor
+// another strategy could be to leave the state in core.Block and have Monitor
+// query it only when the time has run out, with a mutex. this could
+// potentially reduce the amount of channel traffic from 1 msg / pin to
+// 1 / msg per crank.
 
 func (s *Server) MonitorMux(id int, c chan core.MonitorMessage, query chan struct{}, quit chan struct{}) {
 	expire := time.NewTimer(time.Duration(250 * time.Millisecond))

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -1,12 +1,46 @@
 package server
 
-import "github.com/nytlabs/st-core/core"
+import (
+	"time"
+
+	"github.com/nytlabs/st-core/core"
+)
 
 // code for inferring the current state of the st-core pattern
 // and emitting it over the websocket
 
-func (s *Server) MonitorMux(id int, c chan core.MonitorMessage) {
-	for m := range c {
-		s.websocketBroadcast(Update{Action: INFO, Type: BLOCK, Data: wsInfo{wsId{id}, m}})
+func (s *Server) MonitorMux(id int, c chan core.MonitorMessage, query chan struct{}, quit chan struct{}) {
+	expire := time.NewTimer(time.Duration(100 * time.Millisecond))
+	var state core.MonitorMessage
+	running := false
+	for {
+		select {
+		case m := <-c:
+			state = m
+			expire.Reset(time.Duration(100 * time.Millisecond))
+			if !running {
+				running = true
+				s.websocketBroadcast(Update{Action: INFO, Type: BLOCK, Data: wsInfo{wsId{id}, core.MonitorMessage{
+					core.BI_RUNNING,
+					nil,
+					time.Now(),
+				}}})
+			}
+		case <-expire.C:
+			s.websocketBroadcast(Update{Action: INFO, Type: BLOCK, Data: wsInfo{wsId{id}, state}})
+			running = false
+		case <-quit:
+			return
+		case <-query:
+			if running {
+				s.websocketBroadcast(Update{Action: INFO, Type: BLOCK, Data: wsInfo{wsId{id}, core.MonitorMessage{
+					core.BI_RUNNING,
+					nil,
+					time.Now(),
+				}}})
+			} else {
+				s.websocketBroadcast(Update{Action: INFO, Type: BLOCK, Data: wsInfo{wsId{id}, state}})
+			}
+		}
 	}
 }

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -10,20 +10,20 @@ import (
 // and emitting it over the websocket
 
 func (s *Server) MonitorMux(id int, c chan core.MonitorMessage, query chan struct{}, quit chan struct{}) {
-	expire := time.NewTimer(time.Duration(100 * time.Millisecond))
+	expire := time.NewTimer(time.Duration(250 * time.Millisecond))
 	var state core.MonitorMessage
 	running := false
 	for {
 		select {
 		case m := <-c:
 			state = m
-			expire.Reset(time.Duration(100 * time.Millisecond))
+			expire.Reset(time.Duration(250 * time.Millisecond))
 			if !running {
 				running = true
 				s.websocketBroadcast(Update{Action: INFO, Type: BLOCK, Data: wsInfo{wsId{id}, core.MonitorMessage{
 					core.BI_RUNNING,
 					nil,
-					time.Now(),
+					//					time.Now(),
 				}}})
 			}
 		case <-expire.C:
@@ -36,7 +36,7 @@ func (s *Server) MonitorMux(id int, c chan core.MonitorMessage, query chan struc
 				s.websocketBroadcast(Update{Action: INFO, Type: BLOCK, Data: wsInfo{wsId{id}, core.MonitorMessage{
 					core.BI_RUNNING,
 					nil,
-					time.Now(),
+					//					time.Now(),
 				}}})
 			} else {
 				s.websocketBroadcast(Update{Action: INFO, Type: BLOCK, Data: wsInfo{wsId{id}, state}})

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -1,16 +1,12 @@
 package server
 
-import (
-	"time"
-
-	"github.com/nytlabs/st-core/core"
-)
+import "github.com/nytlabs/st-core/core"
 
 // code for inferring the current state of the st-core pattern
 // and emitting it over the websocket
 
-func (s *Server) MonitorMux(id int, c chan time.Time) {
+func (s *Server) MonitorMux(id int, c chan core.MonitorMessage) {
 	for m := range c {
-		s.websocketBroadcast(Update{Action: INFO, Type: BLOCK, Data: wsInfo{wsId{id}, core.CRANK, m}})
+		s.websocketBroadcast(Update{Action: INFO, Type: BLOCK, Data: wsInfo{wsId{id}, m}})
 	}
 }

--- a/server/monitor.go
+++ b/server/monitor.go
@@ -6,8 +6,25 @@ import (
 	"github.com/nytlabs/st-core/core"
 )
 
-// code for inferring the current state of the st-core pattern
-// and emitting it over the websocket
+// monitor infers the current state of an st-core block and emits it over
+// websocket.
+//
+// every start of a block in server also starts a monitor routine. each pin in
+// a block, whether in a receive or broadcast state, emits a
+// core.MonitorMessage to the monitor. A kernel process also emits a message to
+// the monitor. The monitor's job is to only emit state change, i.e., going
+// from one blocking state to another.
+//
+// currently, the sends from block are blocking, meaning that they are limtied
+// by the speed in which monitor can process messages.
+//
+// TODO: test the overhead of blocking sends from block to monitor. currently,
+// every block ges a monitor by default. an optimizing step may be to disable
+// it by default, and affording the querying of state by some API handle.
+//
+// in that capacity, the state should live in core.Block, and MonitorMux would
+// simply use a mutex to transmit it, instead of any continous channel traffic
+// from block to Monitor
 
 func (s *Server) MonitorMux(id int, c chan core.MonitorMessage, query chan struct{}, quit chan struct{}) {
 	expire := time.NewTimer(time.Duration(250 * time.Millisecond))
@@ -23,7 +40,6 @@ func (s *Server) MonitorMux(id int, c chan core.MonitorMessage, query chan struc
 				s.websocketBroadcast(Update{Action: INFO, Type: BLOCK, Data: wsInfo{wsId{id}, core.MonitorMessage{
 					core.BI_RUNNING,
 					nil,
-					//					time.Now(),
 				}}})
 			}
 		case <-expire.C:
@@ -36,7 +52,6 @@ func (s *Server) MonitorMux(id int, c chan core.MonitorMessage, query chan struc
 				s.websocketBroadcast(Update{Action: INFO, Type: BLOCK, Data: wsInfo{wsId{id}, core.MonitorMessage{
 					core.BI_RUNNING,
 					nil,
-					//					time.Now(),
 				}}})
 			} else {
 				s.websocketBroadcast(Update{Action: INFO, Type: BLOCK, Data: wsInfo{wsId{id}, state}})

--- a/server/update.go
+++ b/server/update.go
@@ -69,6 +69,5 @@ type wsSourceModify struct {
 //type Info
 type wsInfo struct {
 	wsId
-	Type  core.BlockInfo `json:"type"`
-	Value interface{}    `json:"value"`
+	core.MonitorMessage
 }

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -149,6 +149,10 @@ func (s *Server) websocketReadPump(c *socket) {
 			}
 
 			s.Unlock()
+
+			for _, b := range s.blocks {
+				b.MonitorQuery <- struct{}{}
+			}
 			// we want to lock for this entire time, so that nothing can interfere
 			// with our state as we are dumping it
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -216,30 +216,16 @@ body {
 }
 .waiting {
     stroke-width: 5px;
-    /*animation: NAME-YOUR-ANIMATION 100ms infinite;
-    stroke: rgba(0, 255, 0, 1);
-    stroke-width: 3px;*/
 }
 .kernel {
     fill: rgba(0, 0, 0, 1);
 }
 .running {
-    animation: HELLO 300ms infinite;
+    animation: RUNROTATE 250ms infinite;
     animation-timing-function: linear;
 }
-@keyframes HELLO {
+@keyframes RUNROTATE {
     to {
         transform: rotate(1turn);
     }
 }
-/*@keyframes NAME-YOUR-ANIMATION {
-    0% {
-        stroke-width: 1px;
-    }
-    50% {
-        stroke-width: 5px;
-    }
-    100% {
-        stroke-width: 1px;
-    }
-}*/

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -211,3 +211,6 @@ body {
     top: 0px;
     width: 100px;
 }
+.error {
+    fill: rgba(255, 0, 0, 1);
+}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -214,3 +214,32 @@ body {
 .error {
     fill: rgba(255, 0, 0, 1);
 }
+.waiting {
+    stroke-width: 5px;
+    /*animation: NAME-YOUR-ANIMATION 100ms infinite;
+    stroke: rgba(0, 255, 0, 1);
+    stroke-width: 3px;*/
+}
+.kernel {
+    fill: rgba(0, 0, 0, 1);
+}
+.running {
+    animation: HELLO 300ms infinite;
+    animation-timing-function: linear;
+}
+@keyframes HELLO {
+    to {
+        transform: rotate(1turn);
+    }
+}
+/*@keyframes NAME-YOUR-ANIMATION {
+    0% {
+        stroke-width: 1px;
+    }
+    50% {
+        stroke-width: 5px;
+    }
+    100% {
+        stroke-width: 1px;
+    }
+}*/

--- a/static/js/component/block.js
+++ b/static/js/component/block.js
@@ -31,7 +31,8 @@ var app = app || {};
                 }, this.props.model.data.name)
             )
 
-            var circleClass = 'route_circle' + ' ' + this.props.model.data.type;
+            var waiting = this.props.model.status.data !== null ? ' ' + this.props.model.status.data : '';
+            var circleClass = 'route_circle' + ' ' + this.props.model.data.type + waiting;
             var cx = this.props.geometry.routeRadius * (direction === 'input' ? -.5 : .5);
             var cy = this.props.geometry.routeRadius * -.5;
 
@@ -82,7 +83,7 @@ var app = app || {};
         },
         componentWillReceiveProps: function(props) {
             if (props.lastCrank !== this.state.lastCrank) {
-                var nextTick = this.state.tick < 8 ? this.state.tick + 1 : 0;
+                var nextTick = this.state.tick < 14 ? this.state.tick + 1 : 0;
 
                 this.setState({
                     tick: nextTick,
@@ -93,14 +94,14 @@ var app = app || {};
         render: function() {
             var state = '';
             if (this.state.lastCrank !== null && this.state.lastCrank !== undefined) {
-                state = ' ' + this.state.lastCrank.type + ' ' + this.state.lastCrank.data
+                state = this.state.lastCrank.type;
             }
             var children = [
                 React.createElement('circle', {
                     cx: 0,
                     cy: 0,
                     r: 5.0,
-                    className: 'tick_circle' + state,
+                    className: 'tick_circle' + (state === 'kernel' ? ' ' + state : ''),
                     key: 'tick_bg'
                 }, null),
                 React.createElement('circle', {
@@ -109,12 +110,13 @@ var app = app || {};
                     r: 3.0,
                     key: 'tick',
                     fill: 'red',
-                    className: 'ticker_' + this.state.tick,
+                    className: 'ticker_' + Math.floor(this.state.tick / 2) + (state === 'running' ? ' ' + state : ''),
                 }, null),
-                React.createElement('text', {}, state)
+                //React.createElement('text', {}, state)
             ]
             return React.createElement('g', {
-                transform: 'translate(' + this.props.x + ', ' + this.props.y + ')'
+                transform: 'translate(' + this.props.x + ', ' + this.props.y + ')',
+                //                className: (state === 'running' ? ' ' + state : ''),
             }, children)
         }
     })

--- a/static/js/component/block.js
+++ b/static/js/component/block.js
@@ -81,7 +81,7 @@ var app = app || {};
             }
         },
         componentWillReceiveProps: function(props) {
-            if (props.lastCrank != this.state.lastCrank) {
+            if (props.lastCrank !== this.state.lastCrank) {
                 var nextTick = this.state.tick < 8 ? this.state.tick + 1 : 0;
 
                 this.setState({
@@ -91,12 +91,16 @@ var app = app || {};
             }
         },
         render: function() {
+            var state = '';
+            if (this.state.lastCrank !== null && this.state.lastCrank !== undefined) {
+                state = ' ' + this.state.lastCrank.type;
+            }
             var children = [
                 React.createElement('circle', {
                     cx: 0,
                     cy: 0,
                     r: 5.0,
-                    className: 'tick_circle',
+                    className: 'tick_circle' + state,
                     key: 'tick_bg'
                 }, null),
                 React.createElement('circle', {

--- a/static/js/component/block.js
+++ b/static/js/component/block.js
@@ -93,7 +93,7 @@ var app = app || {};
         render: function() {
             var state = '';
             if (this.state.lastCrank !== null && this.state.lastCrank !== undefined) {
-                state = ' ' + this.state.lastCrank.type;
+                state = ' ' + this.state.lastCrank.type + ' ' + this.state.lastCrank.data
             }
             var children = [
                 React.createElement('circle', {
@@ -110,7 +110,8 @@ var app = app || {};
                     key: 'tick',
                     fill: 'red',
                     className: 'ticker_' + this.state.tick,
-                }, null)
+                }, null),
+                React.createElement('text', {}, state)
             ]
             return React.createElement('g', {
                 transform: 'translate(' + this.props.x + ', ' + this.props.y + ')'

--- a/static/js/component/block.js
+++ b/static/js/component/block.js
@@ -83,7 +83,7 @@ var app = app || {};
         },
         componentWillReceiveProps: function(props) {
             if (props.lastCrank !== this.state.lastCrank) {
-                var nextTick = this.state.tick < 14 ? this.state.tick + 1 : 0;
+                var nextTick = this.state.tick < 7 ? this.state.tick + .5 : 0;
                 this.setState({
                     tick: nextTick,
                     lastCrank: props.lastCrank,
@@ -109,13 +109,11 @@ var app = app || {};
                     r: 3.0,
                     key: 'tick',
                     fill: 'red',
-                    className: 'ticker_' + Math.floor(this.state.tick / 2) + (state === 'running' ? ' ' + state : ''),
+                    className: (state === 'running' ? state : 'ticker_' + Math.floor(this.state.tick)),
                 }, null),
-                //React.createElement('text', {}, state)
             ]
             return React.createElement('g', {
                 transform: 'translate(' + this.props.x + ', ' + this.props.y + ')',
-                //                className: (state === 'running' ? ' ' + state : ''),
             }, children)
         }
     })

--- a/static/js/model/block.js
+++ b/static/js/model/block.js
@@ -75,6 +75,12 @@ var app = app || {};
             r.routesIndex = index;
             r.parentNode = this;
             r.source = null;
+            // this is an object because it ensures that it is copied
+            // by reference to parent groups so that we can proliferate
+            // changes to route status
+            r.status = {
+                data: null
+            };
             return r
         }.bind(this));
 

--- a/static/js/model/group.js
+++ b/static/js/model/group.js
@@ -79,7 +79,8 @@ var app = app || {};
                     index: r.index,
                     displayIndex: displayIndex[r.direction]++,
                     parentNode: this,
-                    source: r.source
+                    source: r.source,
+                    status: r.status // not copied, actual reference to original status obj.
                 })
             }.bind(this))
         }.bind(this))

--- a/static/js/model/model.js
+++ b/static/js/model/model.js
@@ -146,22 +146,6 @@ var app = app || {};
                 }));
             }.bind(this)
         )
-
-
-        this.crankQueue = [];
-        var _this = this;
-        window.setInterval(function() {
-            _this.crankQueue.forEach(function(m) {
-                if (_this.entities.hasOwnProperty(m.id)) {
-                    _this.entities[m.id].lastCrank = m;
-                }
-            })
-            if (_this.crankQueue.length > 0) {
-                _this.inform();
-            }
-            this.crankQueue = [];
-        }, 300)
-
     }
 
     app.CoreModel.prototype.subscribe = function(onChange) {
@@ -278,17 +262,22 @@ var app = app || {};
                 }
                 break;
             case 'info':
-                this.crankQueue.push(m.data);
+                if (this.entities.hasOwnProperty(m.data.id)) {
+                    this.entities[m.data.id].routes.forEach(function(r) {
+                        if (r.direction === 'input' && m.data.type === 'receive' && m.data.data === r.index) {
+                            r.status.data = 'waiting';
+                        }
+                        if (r.direction === 'output' && m.data.type === 'broadcast' && m.data.data === r.index) {
+                            r.status.data = 'waiting';
+                        }
+                        if (m.data.type === 'kernel' || m.data.type === 'running') {
+                            r.status.data = null;
+                        }
+                    })
 
-                /*     switch (m.data.type) {
-                         case 'crank':
-                             this.crankQueue.push(m.data);
-                             break;
-                         case 'error':
-                             this.crankQueue.push(m);
-                             break;
-                     }*/
-                return;
+                    this.entities[m.data.id].lastCrank = m.data;
+                }
+                break;
             case 'create':
 
                 // create seperate action for child.

--- a/static/js/model/model.js
+++ b/static/js/model/model.js
@@ -152,8 +152,8 @@ var app = app || {};
         var _this = this;
         window.setInterval(function() {
             _this.crankQueue.forEach(function(m) {
-                if (_this.entities.hasOwnProperty(m.data.id)) {
-                    _this.entities[m.data.id].lastCrank = m.data.value;
+                if (_this.entities.hasOwnProperty(m.id)) {
+                    _this.entities[m.id].lastCrank = m;
                 }
             })
             if (_this.crankQueue.length > 0) {
@@ -270,20 +270,24 @@ var app = app || {};
                 } else if (m.type === 'route') {
                     this.entities[m.data.id].data.inputs[m.data.route].value = m.data.value
                 } else if (m.type === 'param') {
-                    var key = {} 
-                    this.entities[m.data.id].data.params.map(function(kv, index, array){
-                      key[kv.name]=index
+                    var key = {}
+                    this.entities[m.data.id].data.params.map(function(kv, index, array) {
+                        key[kv.name] = index
                     })
                     this.entities[m.data.id].data.params[key[m.data.param]].value = m.data.value
                 }
                 break;
             case 'info':
-                switch (m.data.type) {
-                    case 'crank':
-                        this.crankQueue.push(m);
-                        //                        this.entities[m.data.id].lastCrank = m.data.value;
-                        break;
-                }
+                this.crankQueue.push(m.data);
+
+                /*     switch (m.data.type) {
+                         case 'crank':
+                             this.crankQueue.push(m.data);
+                             break;
+                         case 'error':
+                             this.crankQueue.push(m);
+                             break;
+                     }*/
                 return;
             case 'create':
 
@@ -317,8 +321,8 @@ var app = app || {};
                 }
 
                 // for source we need to populate its parameters
-                if (m.type === 'source'){
-                  this.entities[m.data.source.id].data.params = m.data.source.params
+                if (m.type === 'source') {
+                    this.entities[m.data.source.id].data.params = m.data.source.params
                 }
 
                 // if we have a focused group we need to have a way to update the 


### PR DESCRIPTION
this PR affords the display of state for routes in a receiving state or a broadcast state. it also illustrates when when a kernel is processing. 

currently, the magic number threshold is 250ms. If any state change does not occur within 250ms, the state is broadcast over the websocket and displayed in the UI. if the state is changed in the last 250ms, then no message is sent, and the block is considered to be "running"

this PR introduces situations where the observing systems are touching the systems that they are observing, and as such, could potentially lead to performance and mechanical issues down the road. one area of note is that a block can now only move as fast as the speed of its monitor, as the block now contains blocking sends that contain status updates. 

a note is made about this in monitor.go.