### PR TITLE
added more http methods

### DIFF
--- a/core/server.go
+++ b/core/server.go
@@ -110,7 +110,7 @@ func (s *Server) Serve() {
 		if err != nil {
 			log.Println(err)
 		}
-	}).Methods("GET")
+	}).Methods("GET","POST","PUT","DELETE")
 
 	log.Println("starting HTTP server on", server.Addr)
 	go server.ListenAndServe()
@@ -165,6 +165,7 @@ func FromRequest() Spec {
 				out[0] = r.request
 				out[1] = r
 				out[2] = string(body)
+				server.removeHandler <- name
 			case f := <-i:
 				server.removeHandler <- name
 				return f


### PR DESCRIPTION
Let the endpoint accept GET POST DELETE and PUT methods. The user will need to disambiguate using the request object if they actually care about using the method name. This implies, really, that the endpoint should just accept any method, asking the user to care if necessary. For now though, the four normal methods are supported. 

Also explicitly removes the endpoint each crank, rather than overwriting each crank. This means there is no handling of orphan endpoints necessary if you change the endpoint name. 

Below is an echo server, with an error message if no data payload is sent along with the request. 

![image](https://cloud.githubusercontent.com/assets/149211/9832282/080417b2-5944-11e5-807f-42cc58fa781b.png)
