### PR TITLE
Gist integration

### DIFF
--- a/server/block.go
+++ b/server/block.go
@@ -134,7 +134,7 @@ func (s *Server) BlockModifyPositionHandler(w http.ResponseWriter, r *http.Reque
 func (s *Server) CreateBlock(p ProtoBlock) (*BlockLedger, error) {
 	blockSpec, ok := s.library[p.Type]
 	if !ok {
-		return nil, errors.New("spec not found")
+		return nil, errors.New("spec " + p.Type + " not found")
 	}
 
 	block := core.NewBlock(blockSpec)

--- a/server/router.go
+++ b/server/router.go
@@ -58,10 +58,22 @@ func (s *Server) NewRouter() *mux.Router {
 			s.GroupExportHandler,
 		},
 		Route{
+			"GroupExportGist",
+			"/groups/{id}/export/gist",
+			"GET",
+			s.GroupExportGistHandler,
+		},
+		Route{
 			"GroupImport",
 			"/groups/{id}/import",
 			"POST",
 			s.GroupImportHandler,
+		},
+		Route{
+			"GroupImportGist",
+			"/groups/{id}/import/gist",
+			"GET",
+			s.GroupImportGistHandler,
 		},
 		Route{
 			"GroupModifyLabel",

--- a/server/server.go
+++ b/server/server.go
@@ -29,14 +29,12 @@ const (
 
 // user-session specific settings
 type Settings struct {
-	Autosave        bool
 	GithubUserToken string
 }
 
 // NewSettings returns the default settings object
 func NewSettings() Settings {
 	return Settings{
-		Autosave:        true,
 		GithubUserToken: "",
 	}
 }


### PR DESCRIPTION
Two SUPER basic endpoints for exporting and importing groups as gists. Designed really to start exploring the space, so aren't particularly fancy, but do the job. Uses the settings file so maybe look at the settings file PR first. 