### PR TITLE
reducing render events

### DIFF
--- a/static/js/store/nodes.js
+++ b/static/js/store/nodes.js
@@ -67,10 +67,6 @@ var app = app || {};
         if (route.direction === 'input') {
             route.addListener(this.renderAndEmit.bind(this));
         }
-        // TODO: optimize, these can probably be removed
-        // we only need to render if we are visible...
-        this.geometry();
-        this.renderAndEmit();
     }
 
     Node.prototype.removeRoute = function(id) {
@@ -79,10 +75,6 @@ var app = app || {};
         if (route.direction === 'input') {
             route.removeListener(this.renderAndEmit.bind(this));
         }
-        // TODO: optimize, these can probably be removed
-        // we only need to render if we are visible...
-        this.geometry();
-        this.renderAndEmit();
     }
 
     Node.prototype.renderAndEmit = function() {
@@ -256,7 +248,7 @@ var app = app || {};
         }
 
         this.geometry();
-        this.renderAndEmit();
+        this.render();
 
         if (!!data.position) {
             this.position = data.position;
@@ -431,6 +423,14 @@ var app = app || {};
         }
     }
 
+    function rebuildAscending(id) {
+        nodes[id].geometry();
+        nodes[id].render();
+        if (nodes[id].parent !== null) {
+            rebuildAscending(nodes[id].parent);
+        }
+    }
+
     function addChildToGroup(event) {
         nodes[event.id].data.children.push(event.child);
         nodes[event.child].parent = event.id;
@@ -442,7 +442,9 @@ var app = app || {};
 
         nodes[event.child].connections.forEach(function(connId) {
             addConnectionAscending(event.child, connId);
-        })
+        });
+
+        rebuildAscending(event.id);
 
         // find the top-most visible node and store that id in all child nodes.
         var visibleParent = getVisibleParent(event.child);
@@ -453,8 +455,8 @@ var app = app || {};
                 action: app.Actions.APP_ROUTE_VISIBLE_PARENT,
                 id: route,
                 visibleParent: visibleParent,
-            })
-        })
+            });
+        });
 
         // only need to render the top-most visible node.
         nodes[visibleParent].render();
@@ -472,11 +474,13 @@ var app = app || {};
     function removeChildFromGroup(event) {
         nodes[event.child].routes.forEach(function(id) {
             removeRouteAscending(event.id, id);
-        })
+        });
 
         nodes[event.child].connections.forEach(function(connId) {
             removeConnectionAscending(event.id, connId);
-        })
+        });
+
+        rebuildAscending(event.id);
 
         nodes[event.id].data.children.splice(nodes[event.id].data.children.indexOf(event.child), 1);
 


### PR DESCRIPTION
shaving off ~60ms to render this:
![screen shot 2015-11-15 at 12 34 08 am](https://cloud.githubusercontent.com/assets/597897/11167480/a3270f56-8b30-11e5-9274-340fc223931e.png)

flame graphs (look at timeline / yellow blob on right)

**master**
![screen shot 2015-11-15 at 12 32 32 am](https://cloud.githubusercontent.com/assets/597897/11167481/aa78d474-8b30-11e5-9700-ccf0edb839f8.png)

**with this PR**
![screen shot 2015-11-15 at 12 31 55 am](https://cloud.githubusercontent.com/assets/597897/11167484/b2c35848-8b30-11e5-897c-a65303556d7f.png)

went from 74 render events to 17 render events w/o any change. 