### PR TITLE
fixing automatic link deletion

### DIFF
--- a/server/block.go
+++ b/server/block.go
@@ -265,6 +265,13 @@ func (s *Server) DeleteBlock(id int) error {
 		s.DeleteConnection(k)
 	}
 
+	// delete links attached to this block
+	for _, l := range s.links {
+		if l.Block.Id == id {
+			s.DeleteLink(l.Id)
+		}
+	}
+
 	// remove from group
 	s.DetachChild(b)
 


### PR DESCRIPTION
there is a bug in master where if you delete a block that is connected to a source, the link that connects to the source is *not* deleted. this deletes the link just like the connections are deleted. 