### PR TITLE
Store hidden routes on server

### DIFF
--- a/server/router.go
+++ b/server/router.go
@@ -106,6 +106,12 @@ func (s *Server) NewRouter() *mux.Router {
 			s.GroupDeleteHandler,
 		},
 		Route{
+			"GroupSetRouteVisibility",
+			"/groups/{id}/visibility",
+			"PUT",
+			s.GroupSetRouteVisibilityHandler,
+		},
+		Route{
 			"BlockIndex",
 			"/blocks",
 			"GET",
@@ -267,5 +273,4 @@ func (s *Server) NewRouter() *mux.Router {
 	router.PathPrefix("/").Handler(http.FileServer(http.Dir("./static/")))
 
 	return router
-
 }

--- a/server/server.go
+++ b/server/server.go
@@ -62,10 +62,11 @@ type Server struct {
 func NewServer(settings Settings) *Server {
 	groups := make(map[int]*Group)
 	groups[0] = &Group{
-		Label:    "root",
-		Id:       0,
-		Children: []int{},
-		Parent:   nil,
+		Label:        "root",
+		Id:           0,
+		Children:     []int{},
+		Parent:       nil,
+		HiddenRoutes: make(map[string]struct{}),
 	}
 
 	blocks := make(map[int]*BlockLedger)

--- a/server/update.go
+++ b/server/update.go
@@ -12,6 +12,10 @@ type wsId struct {
 	Id int `json:"id"`
 }
 
+type wsRouteId struct {
+	Id string `json:"id"`
+}
+
 type wsLabel struct {
 	wsId
 	Label string `json:"label"`
@@ -57,6 +61,13 @@ type wsGroupChild struct {
 type wsRouteModify struct {
 	ConnectionNode
 	Value *core.InputValue `json:"value"`
+}
+
+// type GROUPROUTE
+type wsGroupRouteModify struct {
+	Route     wsRouteId `json:"route"`
+	Group     wsId      `json:"group"`
+	IsVisible bool      `json:"isVisible"`
 }
 
 // type PARAM


### PR DESCRIPTION
```
$ curl localhost:7071/groups/4
{"id":4,"label":"","children":[1,2],"position":{"x":847,"y":307},"hiddenRoutes":[]}
$ curl -XPUT localhost:7071/groups/4/visibility -d'{"isVisible":false, "routeId":"4_0_input"}'
$ curl localhost:7071/groups/4
{"id":4,"label":"","children":[1,2],"position":{"x":847,"y":307},"hiddenRoutes":["4_0_input"]}
$ curl -XPUT localhost:7071/groups/4/visibility -d'{"isVisible":true, "routeId":"4_0_input"}'
$ curl localhost:7071/groups/4
{"id":4,"label":"","children":[1,2],"position":{"x":847,"y":307},"hiddenRoutes":[]}
```
and down the websocket comes, on that second curl, 
```
{"action":"update","type":"group","data":{"route":{"id":"4_0_input"},"group":{"id":4},"isVisible":false}}
```