### PR TITLE
Interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ _testmain.go
 *.test
 
 # vim
+*.un~
 *.swp
 
 #binaries 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: go
 
 go:
+  - 1.4
   - 1.5

--- a/core/block.go
+++ b/core/block.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"errors"
-	"log"
 	"sync"
 	"time"
 )
@@ -324,7 +323,6 @@ func (b *Block) process() Interrupt {
 	var store sync.Locker
 	var ok bool
 	if store, ok = b.routing.Source.(sync.Locker); ok {
-		log.Println("locking")
 		store.Lock()
 	}
 
@@ -337,7 +335,6 @@ func (b *Block) process() Interrupt {
 
 	// unlock the store if necessary
 	if store != nil {
-		log.Println("unlocking")
 		store.Unlock()
 	}
 


### PR DESCRIPTION
This PR simplifies Sources a bit, splitting them into two:
* Interfaces - these hook into external services, typically requiring a Connect block of some sort. Access is mediated asynchronously through a for-select loop.
* Stores - these are in-memory stores for use within streamtools. They are locked by each block connected to them.

This means we can remove the modify-source code, including the Describe method. The old source mutex is moved into the stores, so there's no monkeying around trying to unlock the streaming interfaces. 

This PR also encapsulates the decision not to abstract away access to streaming services. So we have no generic Connect, Receive or Send blocks. The interfaces so far are an NSQ Consumer and a Websocket Client and they have distinct SourceTypes. 

addresses #215 